### PR TITLE
Added metatype for configuring the root URI for the publishser

### DIFF
--- a/com.eclipsesource.jaxrs.publisher/OSGI-INF/metatype/publisher.xml
+++ b/com.eclipsesource.jaxrs.publisher/OSGI-INF/metatype/publisher.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.1.0">
+	<OCD name="OSGi REST Publisher" id="com.eclipsesource.jaxrs.connector" description="OSGi REST Publisher Configuration">
+		<AD name="Root" id="root" type="String" description="The root URI for publishing web services.  Defaults to /services"/>
+	</OCD>
+	<Designate pid="com.eclipsesource.jaxrs.connector">
+		<Object ocdref="com.eclipsesource.jaxrs.connector"/>
+	</Designate>
+</MetaData>

--- a/com.eclipsesource.jaxrs.publisher/build.properties
+++ b/com.eclipsesource.jaxrs.publisher/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.properties
+               plugin.properties,\
+               OSGI-INF/


### PR DESCRIPTION
This will allow you to use tools like the Apache Felix Web Console to configure the root URI for your web services.
