### PR TITLE
fixed encoding issue in GsonProvider

### DIFF
--- a/bundles/com.eclipsesource.jaxrs.provider.gson/src/com/eclipsesource/jaxrs/provider/gson/GsonProvider.java
+++ b/bundles/com.eclipsesource.jaxrs.provider.gson/src/com/eclipsesource/jaxrs/provider/gson/GsonProvider.java
@@ -65,9 +65,11 @@ public class GsonProvider<T> implements MessageBodyReader<T>, MessageBodyWriter<
                        MultivaluedMap<String, Object> httpHeaders,
                        OutputStream entityStream ) throws IOException, WebApplicationException
   {
-    final String json = gson.toJson( object );
-    entityStream.write( json.getBytes( "UTF-8" ) );
-    entityStream.flush();
+    try (final OutputStream out = entityStream) {
+      final String json = gson.toJson( object );
+      out.write( json.getBytes( "UTF-8" ) );
+      out.flush();
+    }
   }
 
   @Override


### PR DESCRIPTION
fix for https://github.com/hstaudacher/osgi-jax-rs-connector/issues/61

I can provide a testcase, but it is holds no value unless the testing platform itself is running with a non UTF-8 charset
