### PR TITLE
Remove lazy activation

### DIFF
--- a/bundles/com.eclipsesource.jaxrs.provider.moxy/META-INF/MANIFEST.MF
+++ b/bundles/com.eclipsesource.jaxrs.provider.moxy/META-INF/MANIFEST.MF
@@ -8,5 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: javax.ws.rs.ext;version="[2.0.0,3.0.0)",
  org.eclipse.persistence.jaxb.rs;version="[2.5.0,3.0.0)",
  org.osgi.framework;version="[1.3.0,2.0.0)"
-Bundle-ActivationPolicy: lazy
 Bundle-Activator: com.eclipsesource.jaxrs.provider.moxy.Activator


### PR DESCRIPTION
The moxy provider does not start properly when running with bndtools.  Removing the lazy activation is also consistent with the other bundles.