### PR TITLE
Fixed ClassCastException when loading configuration.

### DIFF
--- a/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/Configuration.java
+++ b/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/Configuration.java
@@ -68,6 +68,6 @@ public class Configuration implements ManagedService {
     if( interval == null ){
       return DEFAULT_PUBLISH_DELAY;
     }
-    return Long.parseLong( ( String )interval );
+    return ( ( Long )interval );
   }
 }

--- a/tests/com.eclipsesource.jaxrs.publisher.test/src/com/eclipsesource/jaxrs/publisher/internal/Configuration_Test.java
+++ b/tests/com.eclipsesource.jaxrs.publisher.test/src/com/eclipsesource/jaxrs/publisher/internal/Configuration_Test.java
@@ -89,7 +89,7 @@ public class Configuration_Test {
     Hashtable<String, Object> properties = new Hashtable<String, Object>();
     properties.put( Configuration.PROPERTY_ROOT, path );
     properties.put( Configuration.PROPERTY_WADL_DISABLE, disableWadl );
-    properties.put( Configuration.PROPERTY_PUBLISH_DELAY, "4" );
+    properties.put( Configuration.PROPERTY_PUBLISH_DELAY, 4L );
     return properties;
   }
 


### PR DESCRIPTION
Found a problem where Publish Delay is attempted to be parsed from a String but it is declared as a Long in the metatype/publisher.xml and we get an exception:

java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.String
	at com.eclipsesource.jaxrs.publisher.internal.Configuration.getPublishDelay(Configuration.java:78)
	at com.eclipsesource.jaxrs.publisher.internal.Configuration.updated(Configuration.java:46)

Signed-off-by: IVAN GEORGIEV ILIEV <ivan.iliev@musala.com>