### PR TITLE
Issue #119 - Support for getSingleton()

### DIFF
--- a/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/ApplicationConfiguration.java
+++ b/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/ApplicationConfiguration.java
@@ -11,6 +11,7 @@
 package com.eclipsesource.jaxrs.publisher;
 
 import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.core.Application;
 
@@ -33,5 +34,16 @@ public interface ApplicationConfiguration {
    * @see Application#getProperties()
    */
   Map<String, Object> getProperties();
+  
+  /**
+   * <p>
+   * Will be called before the JAX-RS {@link Application} is registered. Please note that 
+   * one {@link ApplicationConfiguration} can overwrite the values of other {@link ApplicationConfiguration}s. It 
+   * depends on the order they are available in the OSGi container.
+   * </p>
+   * 
+   * @see Application#getSingletons()
+   */
+  Set<Object> getSingletons();
   
 }

--- a/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/DefaultApplicationConfiguration.java
+++ b/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/DefaultApplicationConfiguration.java
@@ -12,6 +12,7 @@ package com.eclipsesource.jaxrs.publisher.internal;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.glassfish.jersey.server.ServerProperties;
 
@@ -28,6 +29,12 @@ public class DefaultApplicationConfiguration implements ApplicationConfiguration
     // disable auto discovery on server, as it's handled via OSGI
     properties.put( ServerProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true );
     return properties;
+  }
+
+  @Override
+  public Set<Object> getSingletons() {
+    // no default
+    return null;
   }
 
 }

--- a/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/JerseyContext.java
+++ b/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/JerseyContext.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.ServletException;
 import javax.ws.rs.core.Application;
@@ -63,9 +64,16 @@ public class JerseyContext {
     for( ServiceHolder serviceHolder : services ) {
       Object service = serviceHolder.getService();
       if( service instanceof ApplicationConfiguration ) {
-        Map<String, Object> properties = ( ( ApplicationConfiguration )service ).getProperties();
+        ApplicationConfiguration ac = (ApplicationConfiguration) service;  
+        Map<String, Object> properties = ac.getProperties();
         if( properties != null ) {
           getRootApplication().addProperties( properties );
+        }
+        Set<Object> singletons = ac.getSingletons();
+        if( singletons != null) {
+          for( Object object : singletons ) {
+            getRootApplication().addResource( object );
+          }
         }
       }
     }

--- a/tests/com.eclipsesource.jaxrs.publisher.test/src/com/eclipsesource/jaxrs/publisher/internal/JerseyContext_Test.java
+++ b/tests/com.eclipsesource.jaxrs.publisher.test/src/com/eclipsesource/jaxrs/publisher/internal/JerseyContext_Test.java
@@ -223,6 +223,9 @@ public class JerseyContext_Test {
     Map<String, Object> map = new HashMap<>();
     map.put( "foo", "bar" );
     when( appConfig.getProperties() ).thenReturn( map );
+    Set<Object> set = new HashSet<Object>();
+    set.add( "test" );
+    when( appConfig.getSingletons()).thenReturn( set );
     when( context.getService( reference ) ).thenReturn( appConfig );
     container.add( reference );
     Configuration configuration = createConfiguration( "/test", false, 23L );
@@ -235,6 +238,8 @@ public class JerseyContext_Test {
 
     Map<String, Object> properties = jerseyContext.getRootApplication().getProperties();
     assertEquals( properties.get( "foo" ), "bar" );
+    Set<Object> singletons = jerseyContext.getRootApplication().getSingletons();
+    assertEquals( singletons.contains( "test" ), true);
   }
 
   @Test


### PR DESCRIPTION
As mentioned in Issue #119 I implemented support for getSingleton() - without this it is not possible to use webdav-jaxrs. Supporting getSingleton() in ApplicationConfiguration, however, allows me to initialize the webdav support as required in 

```
	@Override
	public Set<Object> getSingletons() {
		try {
			return new HashSet<Object>(Arrays.asList(new WebDavContextResolver()));
		} catch (JAXBException e) {
			return null;
		}
	}
```