### PR TITLE
swagger: do not pack slf4j

### DIFF
--- a/build/com.eclipsesource.jaxrs.swagger.all/pom.xml
+++ b/build/com.eclipsesource.jaxrs.swagger.all/pom.xml
@@ -51,7 +51,6 @@
 							!org.apache.commons.*,
 							!org.dom4j.*,
 							!org.joda.*,
-							!org.slf4j.*,
 							!org.w3c.*,
 							!org.xml.sax.*,
 							!com.sun.jdi.*,
@@ -63,7 +62,7 @@
 							*
 						</Import-Package>
 						<Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
-						<Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
+						<Embed-Dependency>*;scope=compile|runtime;inline=true;artifactId=!slf4j-*</Embed-Dependency>
 						<Embed-Directory>dependencies</Embed-Directory>
 						<Embed-StripGroup>true</Embed-StripGroup>
 						<Embed-Transitive>true</Embed-Transitive>


### PR DESCRIPTION
Hello,
this package is named swagger-all.
Do you really want to bundle all dependencies or just the most?
I would prefer to not bundle the slf4j logging, as it is just so a common bundle in the most OSGi based applications.
What do you think about?