### PR TITLE
Fixed following scenarios not returning HTTP Error 503 while Jersey s…

### DIFF
--- a/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/RootApplication.java
+++ b/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/RootApplication.java
@@ -36,15 +36,14 @@ public class RootApplication extends Application {
 
   void addResource( Object resource ) {
     synchronized( lock ) {
-      resources.add( resource );
-      dirty = true;
+      dirty = resources.add( resource );
     }
   }
 
-  void removeResource( Object resource ) {
+  boolean removeResource( Object resource ) {
     synchronized( lock ) {
-      resources.remove( resource );
-      dirty = true;
+      dirty = resources.remove( resource );
+      return dirty;
     }
   }
 

--- a/tests/com.eclipsesource.jaxrs.publisher.test/pom.xml
+++ b/tests/com.eclipsesource.jaxrs.publisher.test/pom.xml
@@ -50,6 +50,13 @@
                 <versionRange>[2.3.0,4.0.0)</versionRange>
               </restrictTo>
             </filter>
+			 <filter>
+				<type>eclipse-plugin</type>
+				<id>org.mockito.mockito-all</id>
+				<restrictTo>
+				   <version>1.9.5</version>
+				</restrictTo>
+			 </filter>
           </filters>
         </configuration>
       </plugin>      
@@ -69,6 +76,11 @@
       <version>${mockito-version}</version>
       <scope>test</scope>
     </dependency>
+	<dependency>
+	  <groupId>org.mockito</groupId>
+	  <artifactId>mockito-all</artifactId>
+	  <version>${mockito-version}</version>
+	</dependency>
   </dependencies>
   
 </project>


### PR DESCRIPTION
…hould not be ready anymore to service requests and may lead to exceptions:

1) While the Jersey servlet is being destroyed and a request is incoming
2) When a resource is removed, but Jersey is not yet republished, if a request comes that would get routed to this resource this will lead to exceptions instead of a 503 as expected.

Signed-off-by: IVAN GEORGIEV ILIEV ivan.iliev@musala.com
