### PR TITLE
#139 swagger.json is missing basePath property from Swagger Configuration …

### DIFF
--- a/bundles/com.eclipsesource.jaxrs.provider.swagger/src/com/eclipsesource/jaxrs/provider/swagger/internal/Activator.java
+++ b/bundles/com.eclipsesource.jaxrs.provider.swagger/src/com/eclipsesource/jaxrs/provider/swagger/internal/Activator.java
@@ -22,6 +22,8 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ManagedService;
 
 import io.swagger.config.ScannerFactory;
+import io.swagger.jaxrs.config.SwaggerContextService;
+import io.swagger.jaxrs.config.SwaggerScannerLocator;
 import io.swagger.jaxrs.listing.ApiListingResource;
 import io.swagger.jaxrs.listing.SwaggerSerializers;
 
@@ -37,6 +39,7 @@ public class Activator implements BundleActivator {
   @Override
   public void start( BundleContext bundleContext ) throws Exception {
     SwaggerConfiguration swaggerConfiguration = registerSwaggerConfiguration( bundleContext );
+    SwaggerScannerLocator.getInstance().putScanner(SwaggerContextService.SCANNER_ID_DEFAULT, new OSGiJaxRsScanner( swaggerConfiguration ));
     ScannerFactory.setScanner( new OSGiJaxRsScanner( swaggerConfiguration ) );
     registrations.add( bundleContext.registerService( ApiListingResource.class.getName(), new ApiListingResource(), null ) );
     registrations.add( bundleContext.registerService( SwaggerSerializers.class.getName(), new SwaggerSerializers(), null ) );


### PR DESCRIPTION
…#139

- registered OSGiJaxRsScanner as "swagger.scanner.id.default" for swagger-core >= 1.5.7 where it doesn't work. For old versions of swagger 1.5.5 for example, there were no issues.