### PR TITLE
#168: Be more tolerant when getting publishDelay from ConfigAdmin

### DIFF
--- a/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/Configuration.java
+++ b/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/Configuration.java
@@ -64,7 +64,13 @@ public class Configuration implements ManagedService {
     if( interval == null ){
       return DEFAULT_PUBLISH_DELAY;
     }
-    return ( ( Long )interval );
+    if ( interval instanceof Long ) {
+      return ( ( Long ) interval ).longValue();
+    }
+    if ( interval instanceof Integer ) {
+      return ( ( Integer ) interval ).longValue(); 
+    }
+    return ( Long.parseLong( interval.toString() ) );
   }
 
   public long getPublishDelay() {


### PR DESCRIPTION
Since we've been hit by this problem here is a patch that makes parsing the ConfigAdmin values more tolerant. To the best of my knowledge CM doesn't do automatic value coercion and (in the case of fileinstall/Karaf CM) will simply use String properties. AFAIK it has always been the responsibility of the callee to parse properties properly, or at least not throw CCEs.
With this fix we properly consume Long/Integer/String values and only throw a NumberFormatException as last resort.
