### PR TITLE
Adding unification of the port types

### DIFF
--- a/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/JAXRSConnector.java
+++ b/bundles/com.eclipsesource.jaxrs.publisher/src/com/eclipsesource/jaxrs/publisher/internal/JAXRSConnector.java
@@ -201,7 +201,7 @@ public class JAXRSConnector {
     HttpService result = null;
     for( ServiceHolder serviceHolder : serviceHolders ) {
       Object servicePort = getPort( serviceHolder );
-      if( servicePort.equals( port ) ) {
+      if( String.valueOf(servicePort).equals( port ) ) {
         result = ( HttpService )serviceHolder.getService();
       }
     }


### PR DESCRIPTION
The JAXRSConnector checks if the ports of the HTTP Service implementation and the registered resource are equal. In some cases, the value of HTTP Service port is Integer and the check fails.

I'm using the Equinox HTTP Service implementation which registers 
> {org.osgi.service.http.HttpService}={http.port=80, service.pid=org.eclipse.equinox.http.HttpService-http, http.address=ALL, service.vendor=IBM, service.description=OSGi Http Service - IBM Implementation, http.scheme=http, http.timeout=30, service.id=106, service.bundleid=91, service.scope=bundle}

```java
  private HttpService findHttpServiceForPort( Object port ) {
    ServiceHolder[] serviceHolders = httpServices.getServices();
    HttpService result = null;
    for( ServiceHolder serviceHolder : serviceHolders ) {
      Object servicePort = getPort( serviceHolder );
      // servicePort is Integer
      // port is String
      if( servicePort.equals( port ) ) {
        result = ( HttpService )serviceHolder.getService();
      }
    }
    return result;
  }
```